### PR TITLE
Update env_setup with English instructions and code

### DIFF
--- a/notebooks/env_setup.ipynb
+++ b/notebooks/env_setup.ipynb
@@ -1,0 +1,81 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f97b927a",
+   "metadata": {},
+   "source": [
+    "# Environment Setup Progress\n",
+    "\n",
+    "This notebook outlines the initial setup steps that were already completed for the project.\n",
+    "\n",
+    "1. Downloaded the required datasets from Kaggle using the command line.\n",
+    "2. Created an S3 bucket and uploaded the downloaded data.\n",
+    "3. Created a Glue database and table to catalog the raw data.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4026ccd7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download dataset from Kaggle\n",
+    "# Requires Kaggle API credentials (~/.kaggle/kaggle.json)\n",
+    "!kaggle datasets download -d <owner/dataset-name> -p ./data\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae72483a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create S3 bucket and upload files\n",
+    "!aws s3 mb s3://my-text-data-bucket\n",
+    "!aws s3 cp ./data s3://my-text-data-bucket/ --recursive\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6c4cba2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "\n",
+    "glue = boto3.client('glue')\n",
+    "\n",
+    "# Create a Glue database if it doesn't already exist\n",
+    "try:\n",
+    "    glue.create_database(DatabaseInput={'Name': 'text_data_db'})\n",
+    "except glue.exceptions.AlreadyExistsException:\n",
+    "    pass\n",
+    "\n",
+    "# Example table creation (schema simplified)\n",
+    "try:\n",
+    "    glue.create_table(\n",
+    "        DatabaseName='text_data_db',\n",
+    "        TableInput={\n",
+    "            'Name': 'raw_news',\n",
+    "            'StorageDescriptor': {\n",
+    "                'Columns': [\n",
+    "                    {'Name': 'date', 'Type': 'string'},\n",
+    "                    {'Name': 'title', 'Type': 'string'},\n",
+    "                ],\n",
+    "                'Location': 's3://my-text-data-bucket/snp_news/'\n",
+    "            }\n",
+    "        }\n",
+    "    )\n",
+    "except glue.exceptions.AlreadyExistsException:\n",
+    "    pass\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- update `notebooks/env_setup.ipynb` with English descriptions
- add example commands for Kaggle download, S3 operations, and Glue database/table creation

## Testing
- `pip install nbformat -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842ae5df1988329b0f8c2006d16ba5c